### PR TITLE
Include new gfw-assets header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,17 @@
         picker: '#transifexTranslateElement',
         api_key: "9eda410a7db74687ba40771c56abd357",
         detectlang: false,
-        site: 'gfw-global'
+        site: 'gfw-howto',
+        ribbon: 'How to',
+        menuOptions:
+        {
+          options: [
+            {
+              title: 'logo',
+              url: '/'
+            }
+          ]
+        }
       };
     </script>
     <script id="loader-gfw" data-current=".shape-howto" src="http://gfw-assets.s3.amazonaws.com/static/gfw-assets.nightly.js"></script>
@@ -31,7 +41,6 @@
     <div id="headerGfw"></div>
 
     <div class="l-wrapper">
-      <h1 class="l-logo"><a href="{{site.baseurl}}/">GFW How to portal <span class="ribbon"><span>How to</span></span></a></h1>
       <aside id="asideView" class="l-aside">
         {% include aside.html %}
       </aside>

--- a/assets/scss/_layout.scss
+++ b/assets/scss/_layout.scss
@@ -48,7 +48,7 @@
       right: 0;
       line-height: 1;
       font-weight: 500;
-      font-size: 10px;      
+      font-size: 10px;
       text-transform: uppercase;
       transform: translate(5px,8px);
 
@@ -80,7 +80,7 @@
 .l-aside {
   display: none;
   width: $aside-width;
-  padding-top: 90px;
+  padding-top: 40px;
   background: #f7f8f8;
   @media (min-width: $br-mobile){
     display: block;

--- a/assets/scss/modules/_header.scss
+++ b/assets/scss/modules/_header.scss
@@ -1,8 +1,8 @@
 .m-header {
-  padding: 70px 15px 40px;
+  padding: 20px 15px 40px;
   position: relative;
   @media (min-width: $br-mobile){
-    padding: 70px 40px 0;
+    padding: 20px 40px 0;
   }
 
   h2 {

--- a/css/main.css
+++ b/css/main.css
@@ -134,7 +134,7 @@ button {
 .l-aside {
   display: none;
   width: 265px;
-  padding-top: 90px;
+  padding-top: 40px;
   background: #f7f8f8; }
   @media (min-width: 850px) {
     .l-aside {
@@ -220,11 +220,11 @@ button {
       text-decoration: underline; }
 
 .m-header {
-  padding: 70px 15px 40px;
+  padding: 20px 15px 40px;
   position: relative; }
   @media (min-width: 850px) {
     .m-header {
-      padding: 70px 40px 0; } }
+      padding: 20px 40px 0; } }
   .m-header h2 {
     font-size: 40px;
     font-weight: 300;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A starter project including full setup for Jekyll, GulpJS, SASS & BrowserSync",
   "main": "gulpfile.js",
   "scripts": {
+    "start": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Vizzuality",


### PR DESCRIPTION
Included new gfw-assets header bar removing the logo and fixing style issues.

Tested locally so won't work until this is deployed https://github.com/Vizzuality/gfw-assets/pull/131

![image](https://user-images.githubusercontent.com/10500650/31897918-0aa4595c-b818-11e7-8f51-1f96e232079e.png)

🙏 remember to clean cache!
