### PR TITLE
Updating whom to contact FAQ and contact-us slug

### DIFF
--- a/_posts/01-01-01-faq-whom-contact-with.questions.md
+++ b/_posts/01-01-01-faq-whom-contact-with.questions.md
@@ -6,9 +6,9 @@ categories: [faqs]
 layout: post
 ---
 <div class="content">
-	<p>Please email general inquiries to <a href='mailto:gfw@wri.org'>gfw@wri.org</a>, or visit the <a href="/about/contact-us" target='_blank'>Contact Us page</a> for other ways to get in touch.</p>
+	<p>Please email general inquiries to <a href='mailto:gfw@wri.org'>gfw@wri.org</a>, or visit the <a href="/about?contactUs=true" target='_blank'>Contact Us page</a> for other ways to get in touch.</p>
 
-	<p>For media inquiries, please contact James Anderson, Communications Officer, World Resources Institute (<a href='mailto:janderson@wri.org'>janderson@wri.org</a>, +1 (202) 729-7608).</p>
+	<p>For media inquiries, please contact Katie Lyons, Communications Manager, World Resources Institute (<a href='mailto:katie.lyons@wri.org'>katie.lyons@wri.org</a>, +1 (202) 729-7968).</p>
 
 	<p>Or, view a <a href='http://www.wri.org/our-work/project/global-forest-watch' target='_blank'>list of staff</a> who work on Global Forest Watch. </p>
 </div>


### PR DESCRIPTION
Updating this page (https://www.globalforestwatch.org/howto/faqs/faq-whom-contact-with-questions.html) with Katie Lyons' info and link to About page's contact us form